### PR TITLE
Added Elastic-Api-Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ You can install the library using [composer](https://getcomposer.org/) with the 
 composer require elastic/elasticsearch-serverless
 ```
 
-You need specify the version, if you want to install an `aplha` or `rc` release, as follows:
+You need specify the version, if you want to install an `alpha` or `rc` release.
+For instance, if you want to install the latest alpha version:
 
 ```bash
-composer require elastic/elasticsearch-serverless:0.1.0-alpha1
+composer require elastic/elasticsearch-serverless:*@alpha
 ```
 
 Please remember that `alpha` releases are quite unstable, the code can change between releases.
-Instead, a release candidate `rc` will not break the backward compatibility but with the possibility
-of having bugs to be fixed.
+Instead, a release candidate `rc` will not break the backward compatibility. Typically an `rc`
+version includes only bug fixes.
 
 ### Instantiate a Client
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -28,10 +28,10 @@ use Psr\Log\LoggerInterface;
 final class Client implements ClientInterface
 {
     const CLIENT_NAME = 'esv';
-    const VERSION = '0.1.0-alpha1';
-    const API_VERSION = '20231031';
-    const API_COMPATIBILITY_HEADER = '%s/vnd.elasticsearch+%s; compatible-with=8';
-    
+    const VERSION = '0.1.0-alpha2';
+    const API_VERSION_HEADER = 'Elastic-Api-Version';
+    const API_VERSION = '2023-10-31';
+   
     use ClientEndpointsTrait;
     use EndpointTrait;
     use NamespaceTrait;

--- a/src/Traits/EndpointTrait.php
+++ b/src/Traits/EndpointTrait.php
@@ -145,7 +145,7 @@ trait EndpointTrait
             $content = is_string($body) ? $body : $this->bodySerialize($body, $headers['Content-Type']);
             $request = $request->withBody($streamFactory->createStream($content));
         }
-        $headers = $this->buildCompatibilityHeaders($headers);
+        $headers = $this->buildApiVersion($headers);
 
         // Headers
         foreach ($headers as $name => $value) {
@@ -159,30 +159,14 @@ trait EndpointTrait
     }
 
     /**
-     * Build the API compatibility headers
-     * transfrom Content-Type and Accept adding vnd.elasticsearch+ and compatible-with
-     * 
-     * @see https://github.com/elastic/elasticsearch-serverless-php/pull/1142
+     * Build the API version header
      */
-    protected function buildCompatibilityHeaders(array $headers): array
+    protected function buildApiVersion(array $headers): array
     {
-        if (isset($headers['Content-Type'])) {
-            if (preg_match('/application\/([^,]+)$/', $headers['Content-Type'], $matches)) {
-                $headers['Content-Type'] = sprintf(Client::API_COMPATIBILITY_HEADER, 'application', $matches[1]);
-            }
-        }
-        if (isset($headers['Accept'])) {
-            $values = explode(',', $headers['Accept']);
-            foreach ($values as &$value) {
-                if (preg_match('/(application|text)\/([^,]+)/', $value, $matches)) { 
-                    $value = sprintf(Client::API_COMPATIBILITY_HEADER, $matches[1], $matches[2]);
-                }
-            }
-            $headers['Accept'] = implode(',', $values);
-        }
+        $headers[Client::API_VERSION_HEADER] = Client::API_VERSION;
         return $headers;
     }
-
+    
     /**
      * Check if the $required parameters are present in $params
      * @throws MissingParameterException

--- a/tests/Traits/EndpointTraitTest.php
+++ b/tests/Traits/EndpointTraitTest.php
@@ -66,34 +66,11 @@ class EndpointTraitTest extends TestCase
         $this->bodySerialize(['foo' => 'bar'], 'Unknown-content-type');
     }
 
-    public function getCompatibilityHeaders()
+    
+    public function testBuildApiVersion()
     {
-        return [
-            [['Content-Type' => 'application/json'], ['Content-Type' => sprintf(Client::API_COMPATIBILITY_HEADER, 'application', 'json')]],
-            [['Accept' => 'application/json'], ['Accept' => sprintf(Client::API_COMPATIBILITY_HEADER, 'application', 'json')]],
-            [['Content-Type' => 'application/x-ndjson'], ['Content-Type' => sprintf(Client::API_COMPATIBILITY_HEADER, 'application', 'x-ndjson')]],
-            [['Accept' => 'application/x-ndjson'], ['Accept' => sprintf(Client::API_COMPATIBILITY_HEADER, 'application', 'x-ndjson')]],
-            [['Content-Type' => 'application/text'], ['Content-Type' => sprintf(Client::API_COMPATIBILITY_HEADER, 'application', 'text')]],
-            [['Accept' => 'text/plain'], ['Accept' => sprintf(Client::API_COMPATIBILITY_HEADER, 'text', 'plain')]],
-            // Multiple values
-            [[
-                'Accept' => 'text/plain,application/json'
-            ], [
-                'Accept' => sprintf(
-                    "%s,%s", 
-                    sprintf(Client::API_COMPATIBILITY_HEADER, 'text', 'plain'), 
-                    sprintf(Client::API_COMPATIBILITY_HEADER, 'application', 'json')
-                )
-            ]],
-        ];
-    }
-
-    /**
-     * @dataProvider getCompatibilityHeaders
-     */
-    public function testBuildCompatibilityHeaders(array $input, array $expected)
-    {
-        $this->assertEquals($expected, $this->buildCompatibilityHeaders($input));
+        $headers = $this->buildApiVersion([]);
+        $this->assertEquals($headers[Client::API_VERSION_HEADER], Client::API_VERSION);
     }
 
     public function getRequestParts(): array
@@ -119,7 +96,7 @@ class EndpointTraitTest extends TestCase
         $host = parse_url($url, PHP_URL_HOST);
         $port = parse_url($url, PHP_URL_PORT);
         $this->assertEquals(empty($port) ? $host : $host . ':' . $port, $request->getHeader('Host')[0]);
-        $headers = $this->buildCompatibilityHeaders($headers);
+        $headers = $this->buildApiVersion($headers);
         foreach ($headers as $name => $value) {
             $header = $request->getHeader($name);
             $this->assertEquals($value, implode(',', $header));


### PR DESCRIPTION
This PR adds the `Elastic-Api-Version` header and remove the `compatibility-width` value in `Content-Type` header.